### PR TITLE
Handle remove observer crash

### DIFF
--- a/SDWebImageLinkPlugin/Classes/SDImageLinkLoader.m
+++ b/SDWebImageLinkPlugin/Classes/SDImageLinkLoader.m
@@ -135,7 +135,7 @@
     loaderContext.progressBlock = progressBlock;
     __block NSProgress *progress;
     progress = [imageProvider loadDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypeImage completionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
-        if (progressBlock && progress) {
+        if (progressBlock && progress && [progress observationInfo]) {
             [progress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted)) context:(__bridge void *)(loaderContext)];
         }
         if (operation.isCancelled) {


### PR DESCRIPTION
In some cases app is crashing while loading link icons in collection view due to progress does not confirms any observers.